### PR TITLE
Fix varios errors and issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,4 @@ include = [
 ]
 
 [dependencies]
-regex = "1"
 nom = "5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,9 +16,16 @@ pub mod parser;
 pub fn theme_search_paths() -> Vec<PathBuf> {
     let mut res: Vec<PathBuf> = Vec::new();
 
-    res.push([var("HOME").unwrap(), String::from(".icons")].iter().collect());
+    res.push(
+        [var("HOME").unwrap(), String::from(".icons")]
+            .iter()
+            .collect(),
+    );
 
-    for i in var("XDG_DATA_DIRS").unwrap_or_else(|_| "/usr/local/share/:/usr/share/".to_string()).split(':') {
+    for i in var("XDG_DATA_DIRS")
+        .unwrap_or_else(|_| "/usr/local/share/:/usr/share/".to_string())
+        .split(':')
+    {
         res.push([i, "icons"].iter().collect());
     }
 
@@ -26,7 +33,6 @@ pub fn theme_search_paths() -> Vec<PathBuf> {
 
     res
 }
-
 
 /// A struct representing a cursor theme.
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -38,7 +44,6 @@ pub struct CursorTheme {
 }
 
 impl CursorTheme {
-
     /// This function searches for a theme with the given name
     /// in the given search paths, and returns an XCursorTheme which
     /// represents it.
@@ -94,7 +99,6 @@ impl CursorTheme {
 
         CursorTheme::load(&self.inherits, self.search_paths.clone()).load_icon(icon_name)
     }
-
 }
 
 /// Loads the specified index.theme file, and returns a `Some` with
@@ -102,7 +106,6 @@ impl CursorTheme {
 /// Returns `None` if the file cannot be read for any reason,
 /// if the file cannot be parsed, or if the `Inherits` key is omitted.
 pub fn theme_inherits(file_path: &Path) -> Option<String> {
-
     let content = std::fs::read_to_string(file_path).ok()?;
 
     parse_theme(&content)
@@ -110,7 +113,7 @@ pub fn theme_inherits(file_path: &Path) -> Option<String> {
 
 /// Parse the content of the `index.theme` and return the `Inherits` value.
 fn parse_theme(content: &str) -> Option<String> {
-    const PATTERN: &'static str = "Inherits";
+    const PATTERN: &str = "Inherits";
 
     let is_xcursor_space_or_separator =
         |&ch: &char| -> bool { ch.is_whitespace() || ch == ';' || ch == ',' };
@@ -143,14 +146,12 @@ fn parse_theme(content: &str) -> Option<String> {
     None
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::parse_theme;
 
     #[test]
     fn parse_inherits() {
-
         let theme_name = String::from("XCURSOR_RS");
 
         let theme = format!("Inherits={}", theme_name.clone());
@@ -161,7 +162,10 @@ mod tests {
 
         assert_eq!(parse_theme(&theme), None);
 
-        let theme = format!("[THEME name]\nInherits   = ,;\t\t{};;;;Tail\n\n", theme_name.clone());
+        let theme = format!(
+            "[THEME name]\nInherits   = ,;\t\t{};;;;Tail\n\n",
+            theme_name.clone()
+        );
 
         assert_eq!(parse_theme(&theme), Some(theme_name.clone()));
 
@@ -173,7 +177,10 @@ mod tests {
 
         assert_eq!(parse_theme(&theme), Some(theme_name.clone()));
 
-        let theme = format!("Inherits = ;;\nSome\tgarbage\nInherits={}", theme_name.clone());
+        let theme = format!(
+            "Inherits = ;;\nSome\tgarbage\nInherits={}",
+            theme_name.clone()
+        );
 
         assert_eq!(parse_theme(&theme), Some(theme_name.clone()));
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,4 +1,7 @@
-use std::{fmt, fmt::{Debug, Formatter}};
+use std::{
+    fmt,
+    fmt::{Debug, Formatter},
+};
 
 use nom::bytes::complete as bytes;
 use nom::number::complete as number;
@@ -15,198 +18,197 @@ struct TOC {
 /// Pixels are in ARGB format, with each byte representing a single channel.
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub struct Image {
-	/// The nominal size of the image.
-	pub size: u32,
+    /// The nominal size of the image.
+    pub size: u32,
 
-	/// The actual width of the image. Doesn't need to match `size`.
-	pub width: u32,
+    /// The actual width of the image. Doesn't need to match `size`.
+    pub width: u32,
 
-	/// The actual height of the image. Doesn't need to match `size`.
-	pub height: u32,
+    /// The actual height of the image. Doesn't need to match `size`.
+    pub height: u32,
 
-	/// The X coordinate of the hotspot pixel (the pixel where the tip of the arrow is situated)
-	pub xhot: u32,
+    /// The X coordinate of the hotspot pixel (the pixel where the tip of the arrow is situated)
+    pub xhot: u32,
 
-	/// The Y coordinate of the hotspot pixel (the pixel where the tip of the arrow is situated)
-	pub yhot: u32,
+    /// The Y coordinate of the hotspot pixel (the pixel where the tip of the arrow is situated)
+    pub yhot: u32,
 
-	/// The amount of time (in milliseconds) that this image should be shown for, before switching to the next.
-	pub delay: u32,
+    /// The amount of time (in milliseconds) that this image should be shown for, before switching to the next.
+    pub delay: u32,
 
-	/// A slice containing the pixels' bytes, in RGBA format (or, in the order of the file).
-	pub pixels_rgba: Vec<u8>,
+    /// A slice containing the pixels' bytes, in RGBA format (or, in the order of the file).
+    pub pixels_rgba: Vec<u8>,
 
-	/// A slice containing the pixels' bytes, in ARGB format.
-	pub pixels_argb: Vec<u8>,
+    /// A slice containing the pixels' bytes, in ARGB format.
+    pub pixels_argb: Vec<u8>,
 }
 
 impl std::fmt::Display for Image {
-	fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-		f.debug_struct("Image")
-		 .field("size", &self.size)
-		 .field("width", &self.width)
-		 .field("height", &self.height)
-		 .field("xhot", &self.xhot)
-		 .field("yhot", &self.yhot)
-		 .field("delay", &self.delay)
-		 .field("pixels", &"/* omitted */")
-		 .finish()
-	}
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Image")
+            .field("size", &self.size)
+            .field("width", &self.width)
+            .field("height", &self.height)
+            .field("xhot", &self.xhot)
+            .field("yhot", &self.yhot)
+            .field("delay", &self.delay)
+            .field("pixels", &"/* omitted */")
+            .finish()
+    }
 }
 
 fn parse_header(i: &[u8]) -> IResult<&[u8], u32> {
     let (i, _) = bytes::tag("Xcur")(i)?;
-	let (i, _) = number::le_u32(i)?;
-	let (i, _) = number::le_u32(i)?;
-	let (i, ntoc) = number::le_u32(i)?;
+    let (i, _) = number::le_u32(i)?;
+    let (i, _) = number::le_u32(i)?;
+    let (i, ntoc) = number::le_u32(i)?;
 
-	Ok((i, ntoc))
+    Ok((i, ntoc))
 }
 
 fn parse_toc(i: &[u8]) -> IResult<&[u8], TOC> {
-	let (i, toctype) = number::le_u32(i)?; // Type
-	let (i, subtype) = number::le_u32(i)?; // Subtype
-	let (i, pos) = number::le_u32(i)?; // Position
+    let (i, toctype) = number::le_u32(i)?; // Type
+    let (i, subtype) = number::le_u32(i)?; // Subtype
+    let (i, pos) = number::le_u32(i)?; // Position
 
-	Ok((i, TOC {
-		toctype,
-		subtype,
-		pos,
-	}))
+    Ok((
+        i,
+        TOC {
+            toctype,
+            subtype,
+            pos,
+        },
+    ))
 }
 
 fn parse_img(i: &[u8]) -> IResult<&[u8], Image> {
-	let (i, _) = bytes::tag([0x24, 0x00, 0x00, 0x00])(i)?; // Header size
-	let (i, _) = bytes::tag([0x02, 0x00, 0xfd, 0xff])(i)?; // Type
-	let (i, size) = number::le_u32(i)?;
-	let (i, _) = bytes::tag([0x01, 0x00, 0x00, 0x00])(i)?; // Image version (1)
-	let (i, width) = number::le_u32(i)?;
-	let (i, height) = number::le_u32(i)?;
-	let (i, xhot) = number::le_u32(i)?;
-	let (i, yhot) = number::le_u32(i)?;
-	let (i, delay) = number::le_u32(i)?;
+    let (i, _) = bytes::tag([0x24, 0x00, 0x00, 0x00])(i)?; // Header size
+    let (i, _) = bytes::tag([0x02, 0x00, 0xfd, 0xff])(i)?; // Type
+    let (i, size) = number::le_u32(i)?;
+    let (i, _) = bytes::tag([0x01, 0x00, 0x00, 0x00])(i)?; // Image version (1)
+    let (i, width) = number::le_u32(i)?;
+    let (i, height) = number::le_u32(i)?;
+    let (i, xhot) = number::le_u32(i)?;
+    let (i, yhot) = number::le_u32(i)?;
+    let (i, delay) = number::le_u32(i)?;
 
-	let img_length: usize = (4 * width * height) as usize;
-	let (i, pixels_slice) = bytes::take(img_length)(i)?;
-	let pixels_argb = rgba_to_argb(pixels_slice);
-	let pixels_rgba = Vec::from(pixels_slice);
+    let img_length: usize = (4 * width * height) as usize;
+    let (i, pixels_slice) = bytes::take(img_length)(i)?;
+    let pixels_argb = rgba_to_argb(pixels_slice);
+    let pixels_rgba = Vec::from(pixels_slice);
 
-	Ok((i, Image {
-		size,
-		width,
-		height,
-		xhot,
-		yhot,
-		delay,
-		pixels_argb,
-		pixels_rgba,
-	}))
+    Ok((
+        i,
+        Image {
+            size,
+            width,
+            height,
+            xhot,
+            yhot,
+            delay,
+            pixels_argb,
+            pixels_rgba,
+        },
+    ))
 }
 
 /// Converts a RGBA slice into an ARGB vec
-/// 
+///
 /// Note that, if the input length is not
 /// a multiple of 4, the extra elements are ignored.
 fn rgba_to_argb(i: &[u8]) -> Vec<u8> {
-	let mut res = Vec::with_capacity(i.len());
+    let mut res = Vec::with_capacity(i.len());
 
-	for rgba in i.chunks(4) {
-                if rgba.len() < 4 { break; }
+    for rgba in i.chunks(4) {
+        if rgba.len() < 4 {
+            break;
+        }
 
-		res.push(rgba[3]);
-		res.push(rgba[0]);
-		res.push(rgba[1]);
-		res.push(rgba[2]);
-	}
+        res.push(rgba[3]);
+        res.push(rgba[0]);
+        res.push(rgba[1]);
+        res.push(rgba[2]);
+    }
 
-	res
+    res
 }
 
 /// Parse an XCursor file into its images.
 pub fn parse_xcursor(content: &[u8]) -> Option<Vec<Image>> {
-	let (mut i, ntoc) = parse_header(content).ok()?;
-	let mut imgs = Vec::with_capacity(ntoc as usize);
+    let (mut i, ntoc) = parse_header(content).ok()?;
+    let mut imgs = Vec::with_capacity(ntoc as usize);
 
-	for _ in 0..ntoc {
-		let (j, toc) = parse_toc(i).ok()?;
-		i = j;
+    for _ in 0..ntoc {
+        let (j, toc) = parse_toc(i).ok()?;
+        i = j;
 
-		if toc.toctype == 0xfffd_0002 {
-			let index = toc.pos as usize..;
-			let (_, img) = parse_img(&content[index]).ok()?;
-			imgs.push(img);
-		}
-	}
+        if toc.toctype == 0xfffd_0002 {
+            let index = toc.pos as usize..;
+            let (_, img) = parse_img(&content[index]).ok()?;
+            imgs.push(img);
+        }
+    }
 
-	Some(imgs)
+    Some(imgs)
 }
 
 #[cfg(test)]
 mod tests {
-	use super::{
-		TOC,
-		parse_header,
-		parse_toc,
-		rgba_to_argb,
-	};
+    use super::{parse_header, parse_toc, rgba_to_argb, TOC};
 
-	// A sample (and simple) XCursor file generated with xcursorgen.
-	// Contains a single 4x4 image.
+    // A sample (and simple) XCursor file generated with xcursorgen.
+    // Contains a single 4x4 image.
     const FILE_CONTENTS: [u8; 128] = [
-        0x58, 0x63, 0x75, 0x72, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00,
-        0x02, 0x00, 0xFD, 0xFF, 0x04, 0x00, 0x00, 0x00, 0x1C, 0x00, 0x00, 0x00, 0x24, 0x00, 0x00, 0x00,
-        0x02, 0x00, 0xFD, 0xFF, 0x04, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00,
-        0x04, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00, 0x80,
-        0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00, 0x80,
-        0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00, 0x80,
-        0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00, 0x80,
+        0x58, 0x63, 0x75, 0x72, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00,
+        0x00, 0x02, 0x00, 0xFD, 0xFF, 0x04, 0x00, 0x00, 0x00, 0x1C, 0x00, 0x00, 0x00, 0x24, 0x00,
+        0x00, 0x00, 0x02, 0x00, 0xFD, 0xFF, 0x04, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x04,
+        0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
+        0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00,
+        0x80, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00,
+        0x00, 0x80, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00, 0x80, 0x00,
+        0x00, 0x00, 0x80, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00, 0x80,
+        0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00, 0x80,
     ];
 
-	#[test]
-	fn test_parse_header() {
-		assert_eq!(
-			parse_header(&FILE_CONTENTS).unwrap(),
-			(&FILE_CONTENTS[16..], 1)
-		)
-	}
+    #[test]
+    fn test_parse_header() {
+        assert_eq!(
+            parse_header(&FILE_CONTENTS).unwrap(),
+            (&FILE_CONTENTS[16..], 1)
+        )
+    }
 
-	#[test]
-	fn test_parse_toc() {
-		let toc = TOC { toctype: 0xfffd0002, subtype: 4, pos: 0x1c };
-		assert_eq!(
-			parse_toc(&FILE_CONTENTS[16..]).unwrap(),
-			(&FILE_CONTENTS[28..], toc)
-		)
-	}
+    #[test]
+    fn test_parse_toc() {
+        let toc = TOC {
+            toctype: 0xfffd0002,
+            subtype: 4,
+            pos: 0x1c,
+        };
+        assert_eq!(
+            parse_toc(&FILE_CONTENTS[16..]).unwrap(),
+            (&FILE_CONTENTS[28..], toc)
+        )
+    }
 
-	#[test]
-	fn test_rgba_to_argb() {
-		let initial: [u8; 8] = [0, 1, 2, 3, 4, 5, 6, 7];
+    #[test]
+    fn test_rgba_to_argb() {
+        let initial: [u8; 8] = [0, 1, 2, 3, 4, 5, 6, 7];
 
-		assert_eq!(
-			rgba_to_argb(&initial),
-			[3u8, 0, 1, 2, 7, 4, 5, 6]
-		)
-	}
+        assert_eq!(rgba_to_argb(&initial), [3u8, 0, 1, 2, 7, 4, 5, 6])
+    }
 
-	#[test]
-	fn test_rgba_to_argb_extra_items() {
-		let initial: [u8; 9] = [0, 1, 2, 3, 4, 5, 6, 7, 8];
-		
-		assert_eq!(
-			rgba_to_argb(&initial),
-			&[3u8, 0, 1, 2, 7, 4, 5, 6]
-		);
-	}
+    #[test]
+    fn test_rgba_to_argb_extra_items() {
+        let initial: [u8; 9] = [0, 1, 2, 3, 4, 5, 6, 7, 8];
 
-	#[test]
-	fn test_rgba_to_argb_no_items() {
-		let initial: &[u8] = &[];
+        assert_eq!(rgba_to_argb(&initial), &[3u8, 0, 1, 2, 7, 4, 5, 6]);
+    }
 
-		assert_eq!(
-			initial,
-			&rgba_to_argb(initial)[..]
-		);
-	}
+    #[test]
+    fn test_rgba_to_argb_no_items() {
+        let initial: &[u8] = &[];
+
+        assert_eq!(initial, &rgba_to_argb(initial)[..]);
+    }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -110,7 +110,9 @@ fn parse_img(i: &[u8]) -> IResult<&[u8], Image> {
 fn rgba_to_argb(i: &[u8]) -> Vec<u8> {
 	let mut res = Vec::with_capacity(i.len());
 
-	for rgba in i.windows(4) {
+	for rgba in i.chunks(4) {
+                if rgba.len() < 4 { break; }
+
 		res.push(rgba[3]);
 		res.push(rgba[0]);
 		res.push(rgba[1]);


### PR DESCRIPTION
This PR consists of 5 commits.

1 - fixes parsing of the `Inherits` field to make it more relax, and those follow other libraries, like libwayland-cursor. I've also removed `regex`, since it was an overkill.

2 - Tests were failing, due  to 23d3daea4b979173d7063b7256c5001a4dc72459 , so this commits fixes them.

3 - Half of the code was indented with tabs, the other half with spaces, something were mixed, so I've just run `cargo fmt` on all the thing to make everything consistent. If you prefer other format options, fill free to provide format spec.

4 - You should respect `XCURSOR_PATH`, since it's a standard env var variable to supply new path to search cursors. This variable is critical for distros with non-standard directory layout like NixOS. I've also followed the behavior of other libs and allow `~` now( I know that it's a shell thing, but it's for the sake of consistency across various impls). 

5 - If the theme is missing on the system, the `load_icon` will go into infinite recursion, I've rewritten all of this logic to traverse safely and avoid stack overflow.

As a side effect, crate was exposing a bunch of functions which has no use for the user, generally speaking, so removing them from public API.

cc @vberger 