### PR TITLE
Bump version to 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xcursor"
 description = "A library for loading XCursor themes"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2018"
 
 authors = ["Samuele Esposito"]


### PR DESCRIPTION
Since cabd6982eeb195010bc1990b42ddc3bfa93ef65f introduced some important bug fixes, it'll be nice to bump the version and make downstream to update, in particular wayland-rs.