### PR TITLE
Disable nom's lexical feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,6 @@ include = [
 ]
 
 [dependencies.nom]
-version = "5.1.1"
+version = "5"
 default-features = false
 features = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,7 @@ include = [
     "Cargo.toml",
 ]
 
-[dependencies]
-nom = "5"
+[dependencies.nom]
+version = "5.1.1"
+default-features = false
+features = ["std"]


### PR DESCRIPTION
**I have not tested this!**

It doesn't look like `xcursor`s parsing code would benefit from it in any way and this significantly reduces the amount of transitive dependencies.

The `std` feature could probably be dropped in favor of the `alloc` feature, though that only really makes sense if this crates becomes a `no_std` crate as well (which, if the `std::env` usage is feature-gated, seems relatively easy to do, but may not actually be useful to anyone).