### PR TITLE
Include documentation files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ readme = "README.md"
 include = [
     "**/*.rs",
     "Cargo.toml",
+    "LICENSE",
+    "README.md",
 ]
 
 [dependencies.nom]


### PR DESCRIPTION
Because of the `include` directive, the `LICENSE` and `README.md` do not end up in the crates, and we need them for packaging in distributions (e.g. in Fedora)

```
xcursor-rs on  add-docs is 📦 v0.3.1 via 🦀 v1.43.0
❯ cargo package
   Packaging xcursor v0.3.1 (/home/michel/src/github/esposm03/xcursor-rs)
   Verifying xcursor v0.3.1 (/home/michel/src/github/esposm03/xcursor-rs)
    Updating crates.io index
   Compiling version_check v0.9.2
   Compiling memchr v2.3.3
   Compiling nom v5.1.1
   Compiling xcursor v0.3.1 (/home/michel/src/github/esposm03/xcursor-rs/target/package/xcursor-0.3.1)
    Finished dev [unoptimized + debuginfo] target(s) in 5.86s

xcursor-rs on  add-docs is 📦 v0.3.1 via 🦀 v1.43.0 took 5s
❯ diff -u <(tar tf ~/src/fedora/specs/rust/xcursor-0.3.1.crate) <(tar tf target/package/xcursor-0.3.1.crate)
--- /proc/self/fd/11    2020-06-08 22:29:09.844296116 -0700
+++ /proc/self/fd/12    2020-06-08 22:29:09.844296116 -0700
@@ -1,5 +1,7 @@
 xcursor-0.3.1/.cargo_vcs_info.json
 xcursor-0.3.1/Cargo.toml
 xcursor-0.3.1/Cargo.toml.orig
+xcursor-0.3.1/LICENSE
+xcursor-0.3.1/README.md
 xcursor-0.3.1/src/lib.rs
 xcursor-0.3.1/src/parser.rs
```

Signed-off-by: Michel Alexandre Salim <michel@michel-slm.name>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/esposm03/xcursor-rs/7)
<!-- Reviewable:end -->
