### PR TITLE
Use a hand-rolled parser instead of nom

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,3 @@ include = [
     "LICENSE",
     "README.md",
 ]
-
-[dependencies]
-nom = "7.0"


### PR DESCRIPTION
nom is ridiculous overkill for a parser that isn't really that complex.
Therefore in order to remove the dependency from `winit`, I'd like to
remove this dependency.

I've replaced it with a simple hand-rolled parser built on top of the
byte slice type.
