### PR TITLE
Fix building with Rust 1.34 and add a GitHub workflow for checking this property

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,3 +24,20 @@ jobs:
       run: cargo fmt -- --check
     - name: Run Clippy
       run: cargo clippy
+
+  msrv:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install and activate old Rust
+      run: |
+        rustup install 1.34.0
+        rustup default 1.34.0
+        cargo --version
+        rustc --version
+    - name: Build
+      run: cargo build
+    - name: Run tests
+      run: cargo test

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -221,7 +221,7 @@ mod tests {
 
     #[test]
     fn test_parse_header() {
-        let mut cursor = Cursor::new(&FILE_CONTENTS);
+        let mut cursor = Cursor::new(&FILE_CONTENTS[..]);
         assert_eq!(parse_header(&mut cursor).unwrap(), (16, 1));
         assert_eq!(cursor.position(), 16);
     }


### PR DESCRIPTION
Hi,

thanks for your input in #20. Turns out I already broke the MSRV that you figured out. Here's a fix for that and a workflow to keep this working.

Edit: I want to highlight that only *tests* do not compile with 1.34. The library itself is fine.